### PR TITLE
Fixed channellist init problem and osd_update

### DIFF
--- a/osd.c
+++ b/osd.c
@@ -826,9 +826,9 @@ void osd_update(struct osd_t* osd, int channel_id)
   int server;
   time_t now;
   
-  channels_geteventid(channel_id, &event, &server);
   switch (osd->osd_state) {
     case OSD_INFO:
+      channels_geteventid(channel_id, &event, &server);
       now = time(NULL);
       if (now >= osd->last_now + 1) {
         osd_show_time(osd);
@@ -840,6 +840,7 @@ void osd_update(struct osd_t* osd, int channel_id)
       }  
       break;
     case OSD_CHANNELLIST:
+      channels_geteventid(osd->channellist_selected_channel, &event, &server);
       if (osd->event != event) {      
         osd_channellist_show_epg(osd, osd->channellist_selected_channel);    
         osd_update = 1;

--- a/pidvbip.c
+++ b/pidvbip.c
@@ -707,7 +707,7 @@ int main(int argc, char* argv[])
               }
           
               osd.channellist_selected_channel = user_channel_id;
-              
+              osd.channellist_start_channel = user_channel_id;
               i = 0;
               int channel_tmp;
               for (channel_tmp = channels_getfirst(); channel_tmp != user_channel_id; channel_tmp = channels_getnext(channel_tmp) )


### PR DESCRIPTION
Fixed two bugs:
- Problem with initial channel in the OSD channellist
- The display was updated by osd_update every second even if not needed.
  This made the channellist slower
