### PR TITLE
Fix list segfault

### DIFF
--- a/events.c
+++ b/events.c
@@ -59,6 +59,15 @@ static void event_free_items(struct event_t* event)
     free(event->episodeUri);
 }
 
+// Clears the contents of an event, but does not remove it from the list.
+static void event_clear(struct event_t* event)
+{
+  event_free_items(event);
+  struct list_head tmp = event->list;
+  memset(event, 0, sizeof(event));
+  event->list = tmp;
+}
+
 void event_free(struct event_t* event)
 {
   if (!event)
@@ -97,8 +106,7 @@ void process_event_message(char* method, struct htsp_message_t* msg)
       fprintf(stderr,"WARNING: eventUpdate received for non-existent event %d, adding instead.\n",eventId);
     }
   } else {
-    event_free_items(event);
-    memset(event,0,sizeof(event));
+    event_clear(event);
     if (strcmp(method,"eventAdd")==0) {
       fprintf(stderr,"WARNING: eventAdd received for existing event %d, updating instead.\n",eventId);
     }

--- a/events.c
+++ b/events.c
@@ -64,7 +64,7 @@ static void event_clear(struct event_t* event)
 {
   event_free_items(event);
   struct list_head tmp = event->list;
-  memset(event, 0, sizeof(event));
+  memset(event, 0, sizeof(struct event_t));
   event->list = tmp;
 }
 


### PR DESCRIPTION
Entries were memset() to zero to erase them on eventUpdate,
unintentionally erasing the list member and corrupting the list they
are contained in. This resets the list member to its original value
after all members have been zeroed.

This fixes a null dereference in `event_delete`, that occurs when the entry after or before the corrupted entry is deleted. There, `list_del` would dereference the next pointer of the previous entry (and vice-versa), dereferencing a zeroed value.

This issue caused pidvbip to crash at least once per day for me, I have not experienced any such crash with this patch applied in some limited testing.
